### PR TITLE
CXA-4320: Removed random key assignment to Hard disk

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -279,7 +279,7 @@ def _add_new_hard_disk_helper(disk_label, size_gb, unit_number, controller_key=1
     disk_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
 
     disk_spec.device = vim.vm.device.VirtualDisk()
-    disk_spec.device.key = random_key
+    #disk_spec.device.key = random_key
     disk_spec.device.deviceInfo = vim.Description()
     disk_spec.device.deviceInfo.label = disk_label
     disk_spec.device.deviceInfo.summary = "{0} GB".format(size_gb)


### PR DESCRIPTION
### What does this PR do?

Removed random key assignment to Hard disk as some times VM provisioning fail due to duplicate key to harddisk. 
### What issues does this PR fix or reference?

By default vcenter assign key to device, not need to assign random key from code.
Now, VM provisioning will not failing during Hard disk creation and able to create more than 10 Hard disk
### Previous Behavior

Sometime VM provision was failing during hard disk creation because of duplicate key and used to get following error:

```
xperience.xformer.deployer.renderers.vm_renderer: 2016-03-16 10:13:36,882 ERROR Provision failure :: Error creating testVM: (vim.fault.FileAlreadyExists) { 
   dynamicType = <unset>, 
   dynamicProperty = (vmodl.DynamicProperty) [], 
   msg = 'Cannot complete the operation because the file or folder /vmfs/volumes/41df8c78-b6c9df47/testVM/testVM_10.vmdk already exists', 
   faultCause = <unset>, 
   faultMessage = (vmodl.LocalizableMessage) [], 
   file = '/vmfs/volumes/41df8c78-b6c9df47/testVM/testVM_10.vmdk' 
} 
```
### New Behavior

VM provisioning not failing during Hard disk creation
