### PR TITLE
CXA-4381: Updated Hard disk creation sorting order to natural.

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -122,6 +122,7 @@ import logging
 import time
 import os.path
 import subprocess
+import re
 
 # Import salt libs
 import salt.utils
@@ -231,6 +232,17 @@ def _str_to_bool(var):
 
     return None
 
+def _atoi(text):
+    return int(text) if text.isdigit() else text
+
+# Sorting list into natural ordering
+def _natural_keys(text):
+    '''
+    alist.sort(key=_natural_keys) sorts in human order
+    http://nedbatchelder.com/blog/200712/human_sorting.html
+    (See Toothy's implementation in the comments)
+    '''
+    return [ _atoi(c) for c in re.split('(\d+)', text) ]
 
 def _get_si():
     '''
@@ -695,7 +707,7 @@ def _manage_devices(devices, vm=None, container_ref=None):
 
     if 'disk' in list(devices.keys()):
         disks_to_create = list(set(devices['disk'].keys()) - set(existing_disks_label))
-        disks_to_create.sort()
+        disks_to_create.sort(key=_natural_keys)
         log.debug("Hard disks to create: {0}".format(disks_to_create)) if disks_to_create else None  # pylint: disable=W0106
         for disk_label in disks_to_create:
             # create the disk


### PR DESCRIPTION
### What does this PR do?

Create Hard disk in  same order as specific order specified in cloud.profiles
### What issues does this PR fix or reference?

Hard disk are not creating in order as specified in VM profile. With in code before disk creation sorting in applied. Now this default sorting behaviour change to natural sorting. 
Reference: http://nedbatchelder.com/blog/200712/human_sorting.html
### Previous Behavior

If Hard disks provide in following order:

```
['Hard disk 1', 'Hard disk 2', 'Hard disk 3', 'Hard disk 4', 'Hard disk 5','Hard disk 6', 'Hard disk 7','Hard disk 8', 'Hard disk 9', 'Hard disk 10', 'Hard disk 11'] 
```

Salt create Hard disk in following order:

```
['Hard disk 1', 'Hard disk 10', 'Hard disk 11', 'Hard disk 2', 'Hard disk 3', 'Hard disk 4', 'Hard disk 5','Hard disk 6', 'Hard disk 7','Hard disk 8', 'Hard disk 9'] 
```
### New Behavior

If Hard disks provide in following order:

```
['Hard disk 1', 'Hard disk 2', 'Hard disk 3', 'Hard disk 4', 'Hard disk 5','Hard disk 6', 'Hard disk 7','Hard disk 8', 'Hard disk 9', 'Hard disk 10', 'Hard disk 11'] 
```

Salt will create Hard disk in same order as above:

```
['Hard disk 1', 'Hard disk 2', 'Hard disk 3', 'Hard disk 4', 'Hard disk 5','Hard disk 6', 'Hard disk 7','Hard disk 8', 'Hard disk 9', 'Hard disk 10', 'Hard disk 11'] 
```
