### PR TITLE
CXA-6928: Added None type check condition in _valid_ip()

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -792,6 +792,10 @@ def _valid_ip(ip_address):
     Return either True or False
     '''
 
+    #check ip_address is Noner
+    if ip_address is None:
+        return False
+
     # Make sure IP has four octets
     octets = ip_address.split('.')
     if len(octets) != 4:


### PR DESCRIPTION
### What does this PR do?

Check None type in _valid_ip() if ip_address is None
### What issues does this PR fix or reference?

CXA-6928
### Previous Behavior

Deployment was failing if IP address is None
### New Behavior

function will return false if ip_address is None
