### PR TITLE
CXA-8705

### DIFF
--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -786,7 +786,7 @@ def _wait_for_vmware_tools(vm_ref, max_wait):
     return False
 
 
-def _valid_ip(ip_address):
+def _valid_ip(ip_address, expected_ip=None):
     '''
     Check if the IP address is valid
     Return either True or False
@@ -829,11 +829,13 @@ def _valid_ip(ip_address):
     for octet in (second_octet, third_octet, fourth_octet):
         if (octet < 0) or (octet > 255):
             return False
+    if expected_ip is not None and ip_address != expected_ip:
+        return False
     # Passed all of the checks
     return True
 
 
-def _wait_for_ip(vm_ref, max_wait):
+def _wait_for_ip(vm_ref, max_wait, expected_ip):
     max_wait_vmware_tools = max_wait
     max_wait_ip = max_wait
     vmware_tools_status = _wait_for_vmware_tools(vm_ref, max_wait_vmware_tools)
@@ -846,14 +848,14 @@ def _wait_for_ip(vm_ref, max_wait):
             log.info("[ {0} ] Waiting to retrieve IPv4 information [{1} s]".format(vm_ref.name, time_counter))
 
         log.info("[ {0} ] Validating IPv4 address [ {1} ]".format(vm_ref.name, vm_ref.summary.guest.ipAddress))
-        if vm_ref.summary.guest.ipAddress and _valid_ip(vm_ref.summary.guest.ipAddress):
+        if vm_ref.summary.guest.ipAddress and _valid_ip(vm_ref.summary.guest.ipAddress, expected_ip):
             log.info("[ {0} ] Successfully retrieved IPv4 information in {1} seconds".format(vm_ref.name, time_counter))
             return vm_ref.summary.guest.ipAddress
         for net in vm_ref.guest.net:
             if net.ipConfig.ipAddress:
                 for current_ip in net.ipConfig.ipAddress:
                     log.info("[ {0} ] Validating IPv4 address [ {1} ]".format(vm_ref.name, current_ip.ipAddress))
-                    if _valid_ip(current_ip.ipAddress):
+                    if _valid_ip(current_ip.ipAddress, expected_ip):
                         log.info("[ {0} ] Successfully retrieved IPv4 information in {1} seconds".format(vm_ref.name, time_counter))
                         return current_ip.ipAddress
         time.sleep(1.0 - ((time.time() - starttime) % 1.0))
@@ -2546,7 +2548,11 @@ def create(vm_):
     # If it a template or if it does not need to be powered on then do not wait for the IP
     out = None
     if not template and power:
-        ip = _wait_for_ip(new_vm_ref, wait_for_ip_timeout)
+        try:
+            expected_ip = vm_['devices']['network']['Network adapter 1']['ip']
+        except:
+            expected_ip = None
+        ip = _wait_for_ip(new_vm_ref, wait_for_ip_timeout, expected_ip)
         if ip:
             log.info("[ {0} ] IPv4 is: {1}".format(vm_name, ip))
             # ssh or smb using ip and install salt only if deploy is True


### PR DESCRIPTION
Accept only expected IP address for static IP provisioning

Problem
=======
During provisioning, sometimes the deployed VM gets a different IP
address ( possibly because the template was created fro a VM carrying
a specific IP address ). Salt picks up this IP address from guest tools
and then continues to proceed. This causes an infinite loop in
wait_for_winexesvc

Solution
========
For static IP provisioning only accept the expected IP address as valid

